### PR TITLE
Change to base version of 3.9

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install package
         run: |
           pip install -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "battery-data-toolkit"
 version = "0.1.1"
 description = "Utilities for reading and manipulating battery testing data"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "LICENSE"
 keywords = ["batteries", "science", "data science"]
 authors = [


### PR DESCRIPTION
Python 3.8 is EOL at the end of CY24, and I prefer the typing changes which were introduced in Py3.9