### PR TITLE
Add ability to store multiple cells per HDF5

### DIFF
--- a/batdata/data.py
+++ b/batdata/data.py
@@ -4,7 +4,7 @@ import logging
 import warnings
 from pathlib import Path
 from datetime import datetime
-from typing import Union, Optional, Collection, List, Dict, Type
+from typing import Union, Optional, Collection, List, Dict, Type, Set
 
 from pandas import HDFStore
 from pandas.io.common import stringify_path
@@ -142,39 +142,37 @@ class BatteryDataset:
 
         return output
 
-    def to_batdata_hdf(self, path_or_buf: Union[str, Path, HDFStore], complevel=0, complib='zlib'):
+    def to_batdata_hdf(self,
+                       path_or_buf: Union[str, Path, HDFStore],
+                       prefix: Optional[str] = None,
+                       append: bool = False,
+                       complevel: int = 0,
+                       complib: str = 'zlib'):
         """Save the data in the standardized HDF5 file format
 
         This function wraps the ``to_hdf`` function of Pandas and supplies fixed values for some options
         so that the data is written in a reproducible format.
 
-        Parameters
-        ----------
-        path_or_buf : str or Path or pandas.HDFStore
-            File path or HDFStore object.
-        complevel : {0-9}, optional
-            Specifies a compression level for data.
-            A value of 0 disables compression.
-        complib : {'zlib', 'lzo', 'bzip2', 'blosc'}, default 'zlib'
-            Specifies the compression library to be used.
-            As of v0.20.2 these additional compressors for Blosc are supported
-            (default if no compressor specified: 'blosc:blosclz'):
-            {'blosc:blosclz', 'blosc:lz4', 'blosc:lz4hc', 'blosc:snappy',
-            'blosc:zlib', 'blosc:zstd'}.
-            Specifying a compression library which is not available issues
-            a ValueError.
+        Args:
+            path_or_buf: File path or HDFStore object.
+            prefix: Prefix to use to differentiate this battery from (optionally) others stored in this HDF5 file
+            append: Whether to clear any existing data in the HDF5 file before writing
+            complevel: Specifies a compression level for data. A value of 0 disables compression.
+            complib: Specifies the compression library to be used.
         """
 
         # Delete the old file if present
-        if isinstance(path_or_buf, (str, Path)) and Path(path_or_buf).is_file():
+        if isinstance(path_or_buf, (str, Path)) and (Path(path_or_buf).is_file() and not append):
             Path(path_or_buf).unlink()
 
         # Store the various datasets
         #  Note that we use the "table" format to allow for partial reads / querying
-        for subset in _subsets:
-            data = getattr(self, subset)
+        for key in _subsets:
+            data = getattr(self, key)
             if data is not None:
-                data.to_hdf(path_or_buf, subset, complevel=complevel,
+                if prefix is not None:
+                    key = f'{prefix}-{key}'
+                data.to_hdf(path_or_buf, key, complevel=complevel,
                             complib=complib, append=False, format='table',
                             index=False)
 
@@ -195,15 +193,16 @@ class BatteryDataset:
             add_metadata(path_or_buf)
 
     @classmethod
-    def from_batdata_hdf(cls, path_or_buf: Union[str, Path, HDFStore], subsets: Optional[Collection[str]] = None):
+    def from_batdata_hdf(cls,
+                         path_or_buf: Union[str, Path, HDFStore],
+                         subsets: Optional[Collection[str]] = None,
+                         prefix: Optional[str] = None):
         """Read the battery data from an HDF file
 
-        Parameters
-        ----------
-        path_or_buf : str or pandas.HDFStore or Path
-            File path or HDFStore object.
-        subsets : List of strings
-            Which subsets of data to read from the data file (e.g., raw_data, cycle_stats)
+        Args:
+            path_or_buf: File path or HDFStore object
+            subsets : Which subsets of data to read from the data file (e.g., raw_data, cycle_stats)
+            prefix: Prefix designating which battery extract from this file, if there are multiple datasets
         """
 
         # Determine which datasets to read
@@ -213,12 +212,19 @@ class BatteryDataset:
             read_all = True
 
         data = {}
-        for key in subsets:
-            if key not in _subsets:
-                raise ValueError(f'Unknown subset: {key}')
+        for subset in subsets:
+            # Throw error if user provides an unknown subset name
+            if subset not in _subsets:
+                raise ValueError(f'Unknown subset: {subset}')
+
+            # Prepend the prefix
+            if prefix is not None:
+                key = f'{prefix}-{subset}'
+            else:
+                key = subset
 
             try:
-                data[key] = pd.read_hdf(path_or_buf, key)
+                data[subset] = pd.read_hdf(path_or_buf, key)
             except KeyError as exc:
                 if read_all:
                     continue
@@ -233,6 +239,43 @@ class BatteryDataset:
             metadata = BatteryMetadata.model_validate_json(path_or_buf.root._v_attrs.metadata)
 
         return cls(**data, metadata=metadata)
+
+    @staticmethod
+    def inspect_batdata_hdf(path: Union[str, Path]) -> tuple[BatteryMetadata, Set[Optional[str]]]:
+        """Extract the battery data and the names of cells contained within an HDF5 file
+
+        Args:
+            path: Path to the HDF5 file
+        Returns:
+            - Metadata from this file
+            - List of names of batteries stored within the file
+        """
+
+        with h5py.File(path, 'r') as f:
+            metadata = BatteryMetadata.model_validate_json(f.attrs['metadata'])
+
+            # Get the names by gathering all names before the "-" in group names
+            names = set()
+            for key in f.keys():
+                if '-' not in key:  # From the "default" group
+                    names.add(None)
+                name, _ = key.rsplit("-", 1)
+                names.add(name)
+            return metadata, names
+
+    @staticmethod
+    def get_metadata_from_hdf5(path: Union[str, Path]) -> BatteryMetadata:
+        """Get battery metadata from an HDF file without reading the data
+
+        Args:
+            path: Path to the HDF5 file
+
+        Returns:
+            Metadata from this file
+        """
+
+        with h5py.File(path, 'r') as f:
+            return BatteryMetadata.model_validate_json(f.attrs['metadata'])
 
     def to_batdata_dict(self) -> dict:
         """Generate data in dictionary format
@@ -339,20 +382,6 @@ class BatteryDataset:
             metadata=BatteryMetadata.model_validate_json(metadata),
             **data
         )
-
-    @staticmethod
-    def get_metadata_from_hdf5(path: Union[str, Path]) -> BatteryMetadata:
-        """Get battery metadata from a directory of parquet files without reading them
-
-        Args:
-            path: Path to the HDF5 file
-
-        Returns:
-            Metadata from this file
-        """
-
-        with h5py.File(path, 'r') as f:
-            return BatteryMetadata.model_validate_json(f.attrs['metadata'])
 
     @staticmethod
     def get_metadata_from_parquet(path: Union[str, Path]) -> BatteryMetadata:

--- a/batdata/data.py
+++ b/batdata/data.py
@@ -180,7 +180,8 @@ class BatteryDataset:
         def add_metadata(f: HDFStore):
             """Put the metadata in a standard location at the root of the HDF file"""
             metadata = self.metadata.json()
-            if append and (existing_metadata := f.root._v_attrs.metadata) is not None:
+            if append and 'metadata' in f.root._v_attrs:
+                existing_metadata = f.root._v_attrs.metadata
                 if metadata != existing_metadata:
                     warnings.warn('Metadata already in HDF5 differs from new metadata')
             f.root._v_attrs.metadata = metadata

--- a/batdata/data.py
+++ b/batdata/data.py
@@ -179,7 +179,11 @@ class BatteryDataset:
         # Create logic for adding metadata
         def add_metadata(f: HDFStore):
             """Put the metadata in a standard location at the root of the HDF file"""
-            f.root._v_attrs.metadata = self.metadata.json()
+            metadata = self.metadata.json()
+            if append and (existing_metadata := f.root._v_attrs.metadata) is not None:
+                if metadata != existing_metadata:
+                    warnings.warn('Metadata already in HDF5 differs from new metadata')
+            f.root._v_attrs.metadata = metadata
 
         # Apply the metadata addition function
         path_or_buf = stringify_path(path_or_buf)

--- a/batdata/data.py
+++ b/batdata/data.py
@@ -201,13 +201,18 @@ class BatteryDataset:
     def from_batdata_hdf(cls,
                          path_or_buf: Union[str, Path, HDFStore],
                          subsets: Optional[Collection[str]] = None,
-                         prefix: Optional[str] = None):
+                         prefix: Union[str, None, int] = None) -> 'BatteryDataset':
         """Read the battery data from an HDF file
+
+        Use :meth:`all_cells_from_batdata_hdf` to read all datasets from a file.
 
         Args:
             path_or_buf: File path or HDFStore object
             subsets : Which subsets of data to read from the data file (e.g., raw_data, cycle_stats)
-            prefix: Prefix designating which battery extract from this file, if there are multiple datasets
+            prefix: (``str``) Prefix designating which battery extract from this file,
+                or (``int``) index within the list of available prefixes, sorted alphabetically.
+                The default is to read the default prefix (``None``).
+
         """
 
         # Determine which datasets to read
@@ -215,6 +220,11 @@ class BatteryDataset:
         if subsets is None:
             subsets = _subsets
             read_all = True
+
+        # Determine which prefix to read, if an int is provided
+        if isinstance(prefix, int):
+            _, prefixes = cls.inspect_batdata_hdf(path_or_buf)
+            prefix = sorted(prefixes)[prefix]
 
         data = {}
         for subset in subsets:

--- a/batdata/data.py
+++ b/batdata/data.py
@@ -171,7 +171,7 @@ class BatteryDataset:
             data = getattr(self, key)
             if data is not None:
                 if prefix is not None:
-                    key = f'{prefix}-{key}'
+                    key = f'{prefix}_{key}'
                 data.to_hdf(path_or_buf, key, complevel=complevel,
                             complib=complib, append=False, format='table',
                             index=False)
@@ -224,7 +224,7 @@ class BatteryDataset:
 
             # Prepend the prefix
             if prefix is not None:
-                key = f'{prefix}-{subset}'
+                key = f'{prefix}_{subset}'
             else:
                 key = subset
 
@@ -281,10 +281,13 @@ class BatteryDataset:
             # Get the names by gathering all names before the "-" in group names
             names = set()
             for key in f.keys():
-                if '-' not in key:  # From the "default" group
-                    names.add(None)
-                name, _ = key.rsplit("-", 1)
-                names.add(name)
+                for subset in _subsets:
+                    if key.endswith(subset):
+                        name = key[:-len(subset) - 1]
+                        if len(name) == 0:
+                            names.add(None)  # From the default group
+                        else:
+                            names.add(name)
             return metadata, names
 
     @staticmethod

--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -34,10 +34,16 @@ test_a.to_batdata_hdf('test.h5', prefix='a')
 test_b.to_batdata_hdf('test.h5', prefix='b', append=True)  # Append is mandatory
 ```
 
-Load a specific cell by providing the prefix on load
+Load a specific cell by providing a specific prefix on load
 
 ```python
 test_a = BatteryDataset.from_batdata_hdf('test.h5', prefix='a')
+```
+
+or load any of the included cells by providing an index
+
+```python
+test_a = BatteryDataset.from_batdata_hdf('test.h5', prefix=0)
 ```
 
 Load all cells by iterating over them:

--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -40,6 +40,13 @@ Load a specific cell by providing the prefix on load
 test_a = BatteryDataset.from_batdata_hdf('test.h5', prefix='a')
 ```
 
+Load all cells by iterating over them:
+
+```python
+for name, cell in BatteryDataset.all_cells_from_batdata_hdf('test.h5'):
+    do_some_processing(cell)
+```
+
 ### Parquet
 
 TBD.

--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -1,0 +1,45 @@
+# The `BatteryDataset` Object
+
+The `BatteryDataset` object is the central object for the battery data tookit. 
+Extractors render vendor-specific data into the `BatteryDataset`,
+schemas describe its contents,
+and post-processing codes manipulate.
+
+## Using the `BatteryDataset` Object
+
+The `BatteryDataset` holds different types of data about a battery in separate Pandas dataframes,
+and metadata describing the source of the data in a `.metadata` attribute.
+
+> TBD: Describe the types of data
+
+## Loading and Saving
+
+The battery data and metadata can be saved in a few different styles, each with different advantages.
+
+### HDF5
+
+The HDF5 file format stores all data about a battery in a single file.
+
+> TBD: Explain that we use `pytables` now, but that may change in the future
+
+#### Multiple Batteries per File
+
+Battery Data Toolkit supports storing data from multiple, related batteries in the same HDF5 file 
+as long as they share the same metadata.
+
+Add multiple batteries into an HDF5 file by providing a "prefix" to name each cell.
+
+```python
+test_a.to_batdata_hdf('test.h5', prefix='a')
+test_b.to_batdata_hdf('test.h5', prefix='b', append=True)  # Append is mandatory
+```
+
+Load a specific cell by providing the prefix on load
+
+```python
+test_a = BatteryDataset.from_batdata_hdf('test.h5', prefix='a')
+```
+
+### Parquet
+
+TBD.

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -106,7 +106,7 @@ def test_multicell_metadata_warning(tmpdir, test_df):
     out_path = os.path.join(tmpdir, 'test.h5')
 
     # Save the cell once, then multiply the current by 2
-    test_df.to_batdata_hdf(out_path, 'a')
+    test_df.to_batdata_hdf(out_path, 'a', append=True)
     test_df.metadata.name = 'Not test data'
     with pytest.warns(UserWarning, match='differs from new metadata'):
         test_df.to_batdata_hdf(out_path, 'b', append=True)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -99,6 +99,11 @@ def test_multi_cell_hdf5(tmpdir, test_df):
     test_b = BatteryDataset.from_batdata_hdf(out_path, prefix='b')
     assert np.isclose(test_a.raw_data['current'] * 2, test_b.raw_data['current']).all()
 
+    # Test reading by index
+    test_0 = BatteryDataset.from_batdata_hdf(out_path, prefix=0)
+    assert np.isclose(test_0.raw_data['current'],
+                      test_a.raw_data['current']).all()
+
     # Iterate over all
     keys = dict(BatteryDataset.all_cells_from_batdata_hdf(out_path))
     assert len(keys)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -3,6 +3,7 @@ import json
 import os
 
 import h5py
+import pytest
 import numpy as np
 import pandas as pd
 from pandas import HDFStore
@@ -99,6 +100,16 @@ def test_multi_cell_hdf5(tmpdir, test_df):
     assert len(keys)
     assert np.isclose(keys['a'].raw_data['current'] * 2,
                       keys['b'].raw_data['current']).all()
+
+
+def test_multicell_metadata_warning(tmpdir, test_df):
+    out_path = os.path.join(tmpdir, 'test.h5')
+
+    # Save the cell once, then multiply the current by 2
+    test_df.to_batdata_hdf(out_path, 'a')
+    test_df.metadata.name = 'Not test data'
+    with pytest.warns(UserWarning, match='differs from new metadata'):
+        test_df.to_batdata_hdf(out_path, 'b', append=True)
 
 
 def test_dict(test_df):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -94,6 +94,12 @@ def test_multi_cell_hdf5(tmpdir, test_df):
     test_b = BatteryDataset.from_batdata_hdf(out_path, prefix='b')
     assert np.isclose(test_a.raw_data['current'] * 2, test_b.raw_data['current']).all()
 
+    # Iterate over all
+    keys = dict(BatteryDataset.all_cells_from_batdata_hdf(out_path))
+    assert len(keys)
+    assert np.isclose(keys['a'].raw_data['current'] * 2,
+                      keys['b'].raw_data['current']).all()
+
 
 def test_dict(test_df):
     # Test writing it


### PR DESCRIPTION
Fixes #61

- [x] Add warning if metadata differs between cells added to a H5
- [x] Add an option that reads any data from an h5, even if a user doesn't know the prefixes 