### PR TITLE
Ensure that bad metadata throws error

### DIFF
--- a/batdata/data.py
+++ b/batdata/data.py
@@ -95,6 +95,8 @@ class BatteryDataset:
             if version_mismatch:
                 warnings.warn('Metadata failed to validate, probably due to version mismatch. Discarding until we support backwards compatibility')
                 self.metadata = BatteryMetadata()
+            else:
+                raise
         self.raw_data = raw_data
         self.cycle_stats = cycle_stats
         self.eis_data = eis_data

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 from pandas import HDFStore
 import pyarrow.parquet as pq
+from pydantic import ValidationError
 from pytest import fixture, raises
 
 from batdata.data import BatteryDataset
@@ -207,3 +208,11 @@ def test_version_warnings(test_df):
     assert 'supplied=super.old.version' in str(w.list[1].message)
     assert 'failed to validate, probably' in str(w.list[2].message)
     assert recovered.metadata.version == __version__
+
+
+def test_bad_metadata():
+    """Ensure bad metadata causes an exception"""
+
+    metadata = {'name': 1}
+    with raises(ValidationError):
+        BatteryDataset(metadata=metadata)


### PR DESCRIPTION
The changes from #66 was too aggressive in ignoring validation errors. Metadata from the latest version should raise a ValidationError if it fails to parse. We should only forgive validation errors from previous versions