### PR TITLE
Skip short cycles during capacity calculation

### DIFF
--- a/batdata/postprocess/integral.py
+++ b/batdata/postprocess/integral.py
@@ -77,6 +77,10 @@ class CapacityPerCycle(CycleSummarizer):
         for cyc, (start_ind, stop_ind) in enumerate(zip_longest(start_inds, start_inds[1:] + 1, fillvalue=len(raw_data))):
             cycle_subset = raw_data.iloc[start_ind:stop_ind]
 
+            # Skip cycles that are too short to have a capacity measurement
+            if len(cycle_subset) < 3:
+                continue
+
             # Perform the integration
             if self.reuse_integrals and 'cycle_energy' in cycle_subset.columns and 'cycle_capacity' in cycle_subset.columns:
                 capacity_change = cycle_subset['cycle_capacity'].values * 3600  # To A-s

--- a/tests/postprocess/test_integral.py
+++ b/tests/postprocess/test_integral.py
@@ -18,7 +18,7 @@ def test_short_cycles():
     """Make sure cycles that are too short for capacity measurements do not cause errors"""
 
     example_data = BatteryDataset(
-        raw_data=pd.DataFrame({'time': range(2), 'current': [1.] * 2, 'voltage': [2.] * 2})
+        raw_data=pd.DataFrame({'time': range(2), 'current': [1.] * 2, 'voltage': [2.] * 2, 'cycle_number': [0] * 2})
     )
     CapacityPerCycle().compute_features(example_data)
     assert np.isnan(example_data.cycle_stats['capacity_charge']).all()

--- a/tests/postprocess/test_integral.py
+++ b/tests/postprocess/test_integral.py
@@ -78,7 +78,9 @@ def test_against_battery_data_gov(file_path):
     cyc_id = 8
     data = BDExtractor().parse_to_dataframe(list((file_path / 'batterydata').glob('p492*')))
     orig_data = \
-    data.cycle_stats[['capacity_discharge', 'capacity_charge', 'energy_discharge', 'energy_charge']].copy().iloc[cyc_id]
+        data.cycle_stats[
+            ['capacity_discharge', 'capacity_charge', 'energy_discharge', 'energy_charge']
+        ].copy().iloc[cyc_id]
 
     # Recompute
     CapacityPerCycle().compute_features(data)


### PR DESCRIPTION
A few of our example data have minimal numbers of measurements.