### PR TITLE
Update Battery Data Hub parser

### DIFF
--- a/batdata/extractors/batterydata.py
+++ b/batdata/extractors/batterydata.py
@@ -175,7 +175,7 @@ class BDExtractor(BatteryDataExtractor):
                 raw_data = convert_raw_signal_to_batdata(nrel_data, self.store_all)
 
                 # Get EIS data, if available
-                if not (nrel_data['Z_Imag_Ohm'].isna()).all():
+                if 'Z_Imag_Ohm' in nrel_data.columns and not (nrel_data['Z_Imag_Ohm'].isna()).all():
                     eis_data = convert_eis_data_to_batdata(nrel_data)
             else:
                 raise ValueError(f'Data type unrecognized: {data_type}')

--- a/batdata/schemas/cycling.py
+++ b/batdata/schemas/cycling.py
@@ -105,7 +105,7 @@ class ColumnSchema(BaseModel):
 
 
 class RawData(ColumnSchema):
-    """Schema for the battery testing data.
+    """Schema for the time series data
 
     Each attribute in this array specifies columns within a :class:`BatteryDataFrame`.
     The schema is defined such that extra columns are allowed by default.


### PR DESCRIPTION
Ensures we can parse data if EIS data are not present and adds function for parsing metadata into our format.