### PR TITLE
Increase minimum python to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "battery-data-toolkit"
 version = "0.4.0"
 description = "Utilities for reading and manipulating battery testing data"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { file = 'LICENSE' }
 keywords = ["batteries", "science", "data science"]
 authors = [


### PR DESCRIPTION
PyTables has moved to 3.10 only and that's a key dependency.

Thanks, @victorventuri for pointing this out