### PR TITLE
Use json_schema_extras to hold additional content

### DIFF
--- a/battdat/schemas/__init__.py
+++ b/battdat/schemas/__init__.py
@@ -23,13 +23,15 @@ class BatteryMetadata(BaseModel, extra='allow'):
     comments: Optional[str] = Field(None, description="Long form comments describing the test")
     version: str = Field(__version__, description="Version of this metadata. Set by the battery-data-toolkit")
     is_measurement: bool = Field(True, description="Whether the data was created observationally as opposed to a computer simulation",
-                                 iri="https://w3id.org/emmo#EMMO_463bcfda_867b_41d9_a967_211d4d437cfb")
+                                 json_schema_extra=dict(
+                                     iri="https://w3id.org/emmo#EMMO_463bcfda_867b_41d9_a967_211d4d437cfb"
+                                 ))
 
     # Fields that describe the test protocol
-    test_protocol: Optional[CyclingProtocol] = Field(None, description="Method used to ")
+    test_protocol: Optional[CyclingProtocol] = Field(None, description="Method used to cycle the battery")
 
     # Field that describe the battery assembly
-    battery: Optional[BatteryDescription] = Field(None, description="Description of the battery being tested")
+    battery: Optional[BatteryDescription] = Field(None, description="Description of the battery being cycled")
 
     # Fields that describe source of synthetic data
     modeling: Optional[ModelMetadata] = Field(None, description="Description of simulation approach")

--- a/battdat/schemas/battery.py
+++ b/battdat/schemas/battery.py
@@ -47,19 +47,31 @@ class BatteryDescription(BaseModel, extra='allow'):
     # Geometry information
     layer_count: Optional[int] = Field(None, description="Number of layers within the battery", gt=1)
     form_factor: Optional[str] = Field(None, description="The general shape of the battery",
-                                       iri="https://w3id.org/emmo/domain/electrochemistry#electrochemistry_1586ef26_6d30_49e3_ae32_b4c9fc181941")
+                                       json_schema_extra=dict(
+                                           iri="https://w3id.org/emmo/domain/electrochemistry#electrochemistry_1586ef26_6d30_49e3_ae32_b4c9fc181941"
+                                       ))
     mass: Optional[float] = Field(None, description="Mass of the entire battery. Units: kg")
     dimensions: Optional[List[float]] = Field(None, description='Dimensions of the battery in plain text.')
 
     # Materials description
     anode: Optional[ElectrodeDescription] = Field(None, description="Name of the anode material",
-                                                  iri="https://w3id.org/emmo/domain/electrochemistry#electrochemistry_b6319c74_d2ce_48c0_a75a_63156776b302")
-    cathode: Optional[ElectrodeDescription] = Field(None, description="Name of the cathode material",
-                                                    iri="https://w3id.org/emmo/domain/electrochemistry#electrochemistry_35c650ab_3b23_4938_b312_1b0dede2e6d5")
-    electrolyte: Optional[ElectrolyteDescription] = Field(None, description="Name of the electrolyte material",
-                                                          iri=("https://w3id.org/emmo/domain/electrochemistry"
-                                                               "#electrochemistry_fb0d9eef_92af_4628_8814_e065ca255d59"))
+                                                  json_schema_extra=dict(
+                                                      iri="https://w3id.org/emmo/domain/electrochemistry#electrochemistry_b6319c74_d2ce_48c0_a75a_63156776b302"
+                                                  ))
+    cathode: Optional[ElectrodeDescription] = Field(
+        None, description="Name of the cathode material",
+        json_schema_extra=dict(
+            iri="https://w3id.org/emmo/domain/electrochemistry#electrochemistry_35c650ab_3b23_4938_b312_1b0dede2e6d5"
+        ))
+    electrolyte: Optional[ElectrolyteDescription] = Field(
+        None, description="Name of the electrolyte material",
+        json_schema_extra=dict(
+            iri="https://w3id.org/emmo/domain/electrochemistry#electrochemistry_fb0d9eef_92af_4628_8814_e065ca255d59"
+        ))
 
     # Performance information
-    nominal_capacity: Optional[float] = Field(None, description="Rated capacity of the battery. Units: A-hr",
-                                              iri="https://w3id.org/emmo/domain/electrochemistry#electrochemistry_9b3b4668_0795_4a35_9965_2af383497a26")
+    nominal_capacity: Optional[float] = Field(
+        None, description="Rated capacity of the battery. Units: A-hr",
+        json_schema_extra=dict(
+            iri="https://w3id.org/emmo/domain/electrochemistry#electrochemistry_9b3b4668_0795_4a35_9965_2af383497a26"
+        ))

--- a/battdat/schemas/battery.py
+++ b/battdat/schemas/battery.py
@@ -14,11 +14,14 @@ class ElectrodeDescription(BaseModel, extra='allow'):
     product: Optional[str] = Field(None, description='Name of the product. Unique to the supplier')
 
     # Relating to the microstructure of the electrode
-    thickness: Optional[float] = Field(None, description='Thickness of the material (units: um)', ge=0)
-    area: Optional[float] = Field(None, description='Total area of the electrode (units: cm2)', ge=0)
-    loading: Optional[float] = Field(None, description='Amount of active material per area (units: mg/cm^2)', ge=0)
-    porosity: Optional[float] = Field(None, description='Relative volume of the electrode occupied by gas (units: %)',
-                                      ge=0, le=100)
+    thickness: Optional[float] = Field(None, description='Thickness of the material', ge=0,
+                                       json_schema_extra=dict(units='um'))
+    area: Optional[float] = Field(None, description='Total area of the electrode', ge=0,
+                                  json_schema_extra=dict(units='cm^2'))
+    loading: Optional[float] = Field(None, description='Amount of active material per area', ge=0,
+                                     json_schema_extra=dict(units='mg/cm^2'))
+    porosity: Optional[float] = Field(None, description='Relative volume of the electrode occupied by gas',
+                                      ge=0, le=100, json_schema_extra=dict(units='%'))
 
 
 class ElectrolyteAdditive(BaseModel, extra='allow'):
@@ -50,8 +53,9 @@ class BatteryDescription(BaseModel, extra='allow'):
                                        json_schema_extra=dict(
                                            iri="https://w3id.org/emmo/domain/electrochemistry#electrochemistry_1586ef26_6d30_49e3_ae32_b4c9fc181941"
                                        ))
-    mass: Optional[float] = Field(None, description="Mass of the entire battery. Units: kg")
-    dimensions: Optional[List[float]] = Field(None, description='Dimensions of the battery in plain text.')
+    mass: Optional[float] = Field(None, description="Mass of the entire battery",
+                                  json_schema_extra=dict(units='kg'))
+    dimensions: Optional[str] = Field(None, description='Dimensions of the battery in plain text.')
 
     # Materials description
     anode: Optional[ElectrodeDescription] = Field(None, description="Name of the anode material",
@@ -71,7 +75,8 @@ class BatteryDescription(BaseModel, extra='allow'):
 
     # Performance information
     nominal_capacity: Optional[float] = Field(
-        None, description="Rated capacity of the battery. Units: A-hr",
+        None, description="Rated capacity of the battery",
         json_schema_extra=dict(
-            iri="https://w3id.org/emmo/domain/electrochemistry#electrochemistry_9b3b4668_0795_4a35_9965_2af383497a26"
+            iri="https://w3id.org/emmo/domain/electrochemistry#electrochemistry_9b3b4668_0795_4a35_9965_2af383497a26",
+            units='A-hr'
         ))

--- a/battdat/schemas/cycling.py
+++ b/battdat/schemas/cycling.py
@@ -9,5 +9,6 @@ class CyclingProtocol(BaseModel, extra='allow'):
     """Test protocol for cell cycling"""
     cycler: Optional[str] = Field(None, description='Name of the cycling machine')
     start_date: Optional[date] = Field(None, description="Date the initial test on the cell began")
-    set_temperature: Optional[float] = Field(None, description="Set temperature for the battery testing equipment. Units: C")
+    set_temperature: Optional[float] = Field(None, description="Set temperature for the battery testing equipment",
+                                             json_schema_extra=dict(units='C'))
     schedule: Optional[str] = Field(None, description="Schedule file used for the cycling machine")

--- a/battdat/schemas/modeling.py
+++ b/battdat/schemas/modeling.py
@@ -36,9 +36,14 @@ class ModelMetadata(BaseModel, extra='allow'):
     references: Optional[List[AnyUrl]] = Field(None, description='List of references associated with the software')
 
     # Details for physics based simulation
-    models: Optional[List[str]] = Field(None, description='Type of mathematical model(s) being used in physics simulation.'
-                                                          'Use terms defined in BattINFO, such as "BatteryEquivalentCircuitModel".',
-                                        root_iri='https://w3id.org/emmo#EMMO_f7ed665b_c2e1_42bc_889b_6b42ed3a36f0')
-    simulation_type: Optional[str] = Field(None, description='Type of simulation being performed. '
-                                                             'Use terms defined in BattINFO, such as "TightlyCoupledModelsSimulation"',
-                                           root_iri='https://w3id.org/emmo#EMMO_e97af6ec_4371_4bbc_8936_34b76e33302f')
+    models: Optional[List[str]] = Field(
+        None, description='Type of mathematical model(s) being used in physics simulation.'
+                          'Use terms defined in BattINFO, such as "BatteryEquivalentCircuitModel".',
+        json_schema_extra=dict(
+            root_iri='https://w3id.org/emmo#EMMO_f7ed665b_c2e1_42bc_889b_6b42ed3a36f0'
+        ))
+    simulation_type: Optional[str] = Field(
+        None, description='Type of simulation being performed. Use terms defined in BattINFO, such as "TightlyCoupledModelsSimulation"',
+        json_schema_extra=dict(
+            root_iri='https://w3id.org/emmo#EMMO_e97af6ec_4371_4bbc_8936_34b76e33302f'
+        ))

--- a/docs/user-guide/schemas/export-schemas.py
+++ b/docs/user-guide/schemas/export-schemas.py
@@ -47,6 +47,8 @@ def expand_terms(metadata_cls: type[BaseModel], fo: TextIO, recurse: bool):
     print('   * - Column', file=fo)
     print('     - Type', file=fo)
     print('     - Description', file=fo)
+    print('     - Units', file=fo)
+    print('     - Definition', file=fo)
     for name, field in metadata_cls.model_fields.items():
         print(f'   * - {name}', file=fo)
 
@@ -64,6 +66,20 @@ def expand_terms(metadata_cls: type[BaseModel], fo: TextIO, recurse: bool):
                 to_recurse.add(cls_type)
 
         print(f'     - {"(**Required**) " if not is_optional else ""}{str(field.description)}', file=fo)
+
+        # Print units
+        if field.json_schema_extra is not None and (units := field.json_schema_extra.get('units')) is not None:
+            print(f'     - {units}', file=fo)
+        else:
+            print('     -', file=fo)
+
+        # Print metadata source
+        if field.json_schema_extra is not None and (iri := field.json_schema_extra.get('iri')) is not None:
+            assert 'emmo' in iri.lower(), f'Found an IRI that is not from EMMO!?'
+            print(f'     - `EMMO <{iri}>`_', file=fo)
+        else:
+            print('     -', file=fo)
+
     print(file=fo)
 
     if recurse:


### PR DESCRIPTION
Use `json_schema_extras` in Field definitions because excess kwargs are getting deprecated. Moving such metadata into a `json_schema_extras` also makes it easier to retrieve that information when rendering metadata into HTML.