### PR TITLE
Updates to fix error with updated Kokam dataset

### DIFF
--- a/battdat/io/batterydata.py
+++ b/battdat/io/batterydata.py
@@ -13,7 +13,7 @@ from battdat.data import BatteryDataset
 from battdat.io.base import DatasetFileReader
 from battdat.schemas import BatteryMetadata, BatteryDescription
 
-_fname_match = re.compile(r'(?P<name>[-\w]+)-(?P<type>summary|raw)\.csv')
+_fname_match = re.compile(r'(?P<name>[-\w]+)[- ](?P<type>summary|raw)\.csv')
 
 logger = logging.getLogger(__name__)
 

--- a/battdat/io/hdf.py
+++ b/battdat/io/hdf.py
@@ -34,12 +34,17 @@ def make_numpy_dtype_from_pandas(df: pd.DataFrame) -> np.dtype:
 
         # Introspect objects to learn more
         if kind == 'O':
-            example = np.array(df[name].iloc[0])
-            dtype = example.dtype
-            kind = dtype.kind
-            shape = example.shape
+            example = df[name].iloc[0]
+            if isinstance(example, (list, np.ndarray)):
+                example = np.array(example)
+                dtype = example.dtype
+                shape = example.shape
+                output.append((name, dtype, shape))
+            else:  # Encode as a string
+                max_len = df[name].apply(str).apply(len).max()
+                output.append((name, np.dtype(f'S{max_len}')))
 
-        if kind in ['S', 'U']:
+        elif kind in ['S', 'U']:
             max_len = df[name].apply(str).apply(len).max()
             output.append((name, np.dtype(f'S{max_len}')))
         elif kind in ['M', 'm', 'V']:

--- a/tests/io/test_hdf.py
+++ b/tests/io/test_hdf.py
@@ -85,3 +85,11 @@ def test_append(tmpdir, prefix):
         # Test bad prefix
         with raises(ValueError, match='No data available for prefix'):
             writer.append_to_table(file, 'example_table', pd.DataFrame({'a': [1., 2.]}), prefix='b')
+
+
+def test_df_missing_strings(tmpdir):
+    df = pd.DataFrame({'a': [None, 'a', 'bb']})
+    with tables.open_file(tmpdir / "example.h5", "w") as file:
+        group = file.create_group('/', name='base')
+        table = write_df_to_table(file, group, 'table', df)
+        assert tuple(table[-1]) == (b'bb',)

--- a/tests/io/test_hdf.py
+++ b/tests/io/test_hdf.py
@@ -89,7 +89,27 @@ def test_append(tmpdir, prefix):
 
 def test_df_missing_strings(tmpdir):
     df = pd.DataFrame({'a': [None, 'a', 'bb']})
+    assert df.dtypes['a'] == object
     with tables.open_file(tmpdir / "example.h5", "w") as file:
         group = file.create_group('/', name='base')
         table = write_df_to_table(file, group, 'table', df)
         assert tuple(table[-1]) == (b'bb',)
+
+
+def test_df_strings(tmpdir):
+    df = pd.DataFrame({'a': ['ccc', 'a', 'bb']})
+    assert df.dtypes['a'] == object
+    with tables.open_file(tmpdir / "example.h5", "w") as file:
+        group = file.create_group('/', name='base')
+        table = write_df_to_table(file, group, 'table', df)
+        assert tuple(table[-1]) == (b'bb',)
+        assert tuple(table[0]) == (b'ccc',)
+
+
+def test_df_lists(tmpdir):
+    df = pd.DataFrame({'a': [[1., 1.], [2., 2.]]})
+    assert df.dtypes['a'] == object
+    with tables.open_file(tmpdir / "example.h5", "w") as file:
+        group = file.create_group('/', name='base')
+        table = write_df_to_table(file, group, 'table', df)
+        assert np.array_equal(table[-1]['a'], [2., 2.])


### PR DESCRIPTION
Found two errors with working with data from NREL:

- [ ] Any "object" is assumed to be a list type when saving arrays, which doesn't work when a dataframe has missing values
- [ ] The file name conventions for BatteryData are not as strict as I thought