### PR TITLE
Check for day rolling over in MACCOR files

### DIFF
--- a/battdat/consistency/time.py
+++ b/battdat/consistency/time.py
@@ -1,0 +1,40 @@
+"""Check for problems across the columns which describe time"""
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List
+
+import numpy as np
+
+from .base import ConsistencyChecker
+from ..data import BatteryDataset
+
+
+@dataclass
+class TestTimeVsTimeChecker(ConsistencyChecker):
+    """Ensure that the test time and timestamp columns agree
+
+    Verify that the difference between the test_time
+    """
+
+    max_inconsistency: float = 0.1
+    """Maximum inconsistency between timestamp and test time (s)"""
+
+    def check(self, dataset: BatteryDataset) -> List[str]:
+        output = []
+        for name, subset in dataset.tables.items():
+            if 'time' not in subset.columns or 'test_time' not in subset.columns:
+                continue
+
+            # Ensure that
+            test_time_normed = subset['test_time'] - subset['test_time'].min()
+            timestamp_normed = subset['time'] - subset['time'].min()
+            diffs = np.abs(test_time_normed - timestamp_normed)
+            max_diff = diffs.max()
+            if max_diff > self.max_inconsistency:
+                idx_max = np.argmax(diffs)
+                date_max = datetime.fromtimestamp(subset['time'].iloc[idx_max])
+                time_max = subset['test_time'].iloc[idx_max]
+                output.append(f'Test times and timestep in dataset "{name}" differ by {max_diff:.1e} seconds in row {idx_max}.'
+                              f' test_time={int(time_max)} s, time={date_max}')
+
+        return output

--- a/docs/source/consistency.rst
+++ b/docs/source/consistency.rst
@@ -22,3 +22,11 @@ Current (``b.consistency.current``)
    :members:
    :undoc-members:
    :show-inheritance:
+
+Current (``b.consistency.time``)
+------------------------------------
+
+.. automodule:: battdat.consistency.time
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/tests/consistency/test_times.py
+++ b/tests/consistency/test_times.py
@@ -1,0 +1,33 @@
+"""Test for inconsistencies in time columns"""
+from datetime import datetime
+
+import numpy as np
+import pandas as pd
+from pytest import fixture
+
+from battdat.consistency.time import TestTimeVsTimeChecker
+from battdat.data import BatteryDataset
+
+
+@fixture()
+def example_dataset():
+    df = pd.DataFrame({
+        'voltage': [1.] * 8,
+        'current': [0.] * 8,
+        'test_time': np.arange(8, dtype=float)
+    })
+    df['time'] = datetime.now().timestamp() + df['test_time']
+    data = BatteryDataset.make_cell_dataset(raw_data=df)
+    data.validate()
+    return data
+
+
+def test_correct_inter(example_dataset):
+    checker = TestTimeVsTimeChecker()
+    assert len(checker.check(example_dataset)) == 0
+
+    example_dataset.raw_data['time'].iloc[4:] += 0.2
+    errors = checker.check(example_dataset)
+    assert len(errors) == 1
+    assert '2.0e-01 seconds' in errors[0]
+    assert 'row 4. test_time=4 s' in errors[0]

--- a/tests/consistency/test_times.py
+++ b/tests/consistency/test_times.py
@@ -17,7 +17,7 @@ def example_dataset():
         'test_time': np.arange(8, dtype=float)
     })
     df['time'] = datetime.now().timestamp() + df['test_time']
-    data = BatteryDataset.make_cell_dataset(raw_data=df)
+    data = BatteryDataset.make_cell_dataset(raw_data=df, cycle_stats=pd.DataFrame({'cycle_number': [0]}))
     data.validate()
     return data
 


### PR DESCRIPTION
Some MACCOR files do not list the date along with the timestamp. We can infer it from the days rolling over and cross-referencing with the "test time" column.