### PR TITLE
Net capacity summarizer

### DIFF
--- a/battdat/postprocess/integral.py
+++ b/battdat/postprocess/integral.py
@@ -47,6 +47,7 @@ class CapacityPerCycle(CycleSummarizer):
     - ``capacity_charge``: Charge capacity per the cycle in A-hr
     - ``energy_charge``: Discharge energy per cycle in J
     - ``energy_discharge``: Charge energy per the cycle in J
+    - ``max_cycled_capacity``: Maximum amount of charge cycled during the cycle, in A-hr
 
     The full definitions are provided in the :class:`~battdat.schemas.cycling.CycleLevelData` schema
     """

--- a/battdat/postprocess/integral.py
+++ b/battdat/postprocess/integral.py
@@ -64,6 +64,7 @@ class CapacityPerCycle(CycleSummarizer):
         output = []
         for name in ['charge', 'discharge']:
             output.extend([f'energy_{name}', f'capacity_{name}'])
+        output.extend(['max_cycled_capacity'])
         return output
 
     def _summarize(self, raw_data: pd.DataFrame, cycle_data: pd.DataFrame):
@@ -95,6 +96,7 @@ class CapacityPerCycle(CycleSummarizer):
             # Estimate if the battery starts as charged or discharged
             max_charge = capacity_change.max()
             max_discharge = -capacity_change.min()
+            cycle_data.loc[cyc, 'max_cycled_capacity'] = (max_charge + max_discharge) / 3600  # To Amp-hour
 
             starts_charged = max_discharge > max_charge
             if np.isclose(max_discharge, max_charge, rtol=0.01):

--- a/battdat/schemas/column.py
+++ b/battdat/schemas/column.py
@@ -277,6 +277,9 @@ class CycleLevelData(ColumnSchema):
     coulomb_efficiency: ColumnInfo = ColumnInfo(description='Fraction of electric charge that is lost during charge and recharge',
                                                 units='%', type=DataType.FLOAT)
     energy_efficiency: ColumnInfo = ColumnInfo(description='Amount of energy lost during charge and discharge', type=DataType.FLOAT)
+    max_cycled_capacity: ColumnInfo = ColumnInfo(description='Maximum amount of charge cycled during cycle',
+                                                 units='A-hr',
+                                                 type=DataType.FLOAT)
 
     # Related to voltage
     discharge_V_average: ColumnInfo = ColumnInfo(description='Average voltage during discharging', units='V', type=DataType.FLOAT)


### PR DESCRIPTION
Includes as output of the `CapacityPerCycle` summarizer the maximum amount of cycled charge, computed as the minimum value of the cumulative integral of current over time subtracted from the maximum value of this integral. Ultimately, answers the question "what is the maximum delta charge one could extract based on this cycle?"