### PR TITLE
Integrate StateOfCharge by charging-state segments

### DIFF
--- a/battdat/postprocess/integral.py
+++ b/battdat/postprocess/integral.py
@@ -8,6 +8,63 @@ import pandas as pd
 from scipy.integrate import cumulative_trapezoid
 
 from battdat.postprocess.base import RawDataEnhancer, CycleSummarizer
+from battdat.schemas.column import ChargingState
+
+
+_REST_CURRENT_THRESHOLD = 1.0e-4
+
+
+def _states_for_integration(data: pd.DataFrame) -> np.ndarray:
+    """Get the charging state used to decide which intervals are integrated.
+
+    A labelled ``state`` column is authoritative.  When it is absent, infer the
+    same states as :class:`~battdat.postprocess.tagging.AddState` without
+    mutating the caller's dataframe.
+    """
+    if 'state' in data:
+        return np.asarray([
+            value.value if isinstance(value, ChargingState) else value
+            for value in data['state'].to_numpy()
+        ])
+
+    current = data['current'].to_numpy()
+    state = np.full(len(current), ChargingState.rest.value, dtype=object)
+    state[current > _REST_CURRENT_THRESHOLD] = ChargingState.charging.value
+    state[current < -_REST_CURRENT_THRESHOLD] = ChargingState.discharging.value
+    return state
+
+
+def _cumulative_trapezoid_by_state(
+        values: np.ndarray,
+        test_time: np.ndarray,
+        state: np.ndarray,
+) -> np.ndarray:
+    """Integrate active, contiguous charging-state segments within one cycle.
+
+    The interval between differently labelled states is intentionally omitted:
+    the dataset does not contain the exact transition time, and assigning its
+    area to either state would introduce an undocumented assumption.  Rest and
+    unknown segments therefore preserve the prior cumulative value.
+    """
+    output = np.zeros(len(values), dtype=float)
+    if len(values) == 0:
+        return output
+
+    segment_starts = np.r_[0, np.flatnonzero(state[1:] != state[:-1]) + 1]
+    segment_stops = np.r_[segment_starts[1:], len(values)]
+    carry = 0.
+    active_states = (ChargingState.charging.value, ChargingState.discharging.value)
+
+    for start, stop in zip(segment_starts, segment_stops):
+        output[start:stop] = carry
+        if state[start] in active_states and stop - start > 1:
+            segment_change = cumulative_trapezoid(
+                values[start:stop], x=test_time[start:stop], initial=0,
+            )
+            output[start:stop] += segment_change
+            carry = output[stop - 1]
+
+    return output
 
 
 class CapacityPerCycle(CycleSummarizer):
@@ -137,6 +194,12 @@ class StateOfCharge(RawDataEnhancer):
         - ``cycled_energy``: Amount of observed energy cycled since the beginning of the cycle, in W-hr
         - ``CE_adjusted_charge``: Amount of charge in the battery relative to the beginning of the cycle, accounting for
             Coulombic Efficiency (CE), in A-hr
+
+    When a ``state`` column is available, each contiguous charging or
+    discharging segment is integrated independently. Rest and unknown segments
+    preserve the preceding cumulative value. If ``state`` is absent, states are
+    inferred from current using the same 0.1 mA rest threshold as
+    :class:`~battdat.postprocess.tagging.AddState`.
     """
     def __init__(self, coulombic_efficiency: float = 1.0):
         """
@@ -186,9 +249,15 @@ class StateOfCharge(RawDataEnhancer):
 
             # Perform the integration
             ce_adj_curr = self._get_CE_adjusted_curr(cycle_subset['current'].to_numpy())
-            capacity_change = cumulative_trapezoid(cycle_subset['current'], x=cycle_subset['test_time'], initial=0)
-            ce_charge = cumulative_trapezoid(ce_adj_curr, x=cycle_subset['test_time'], initial=0)
-            energy_change = cumulative_trapezoid(cycle_subset['current'] * cycle_subset['voltage'], x=cycle_subset['test_time'], initial=0)
+            state = _states_for_integration(cycle_subset)
+            time = cycle_subset['test_time'].to_numpy()
+            capacity_change = _cumulative_trapezoid_by_state(
+                cycle_subset['current'].to_numpy(), time, state,
+            )
+            ce_charge = _cumulative_trapezoid_by_state(ce_adj_curr, time, state)
+            energy_change = _cumulative_trapezoid_by_state(
+                (cycle_subset['current'] * cycle_subset['voltage']).to_numpy(), time, state,
+            )
 
             # Store them in the raw data
             data.loc[cycle_subset['index'], 'cycled_charge'] = capacity_change / 3600  # To A-hr

--- a/tests/postprocess/test_integral.py
+++ b/tests/postprocess/test_integral.py
@@ -110,3 +110,56 @@ def test_reuse_integrals(file_path):
     final_data = example_data.tables['cycle_stats'][
         ['capacity_discharge', 'capacity_charge', 'energy_discharge', 'energy_charge']].copy()
     assert np.isclose(initial_data.values * 2, final_data.values, atol=1e-3).all()
+
+
+def _data_with_rest(rest_time: float, rest_current: float = 0.) -> pd.DataFrame:
+    return pd.DataFrame({
+        'test_time': [0., 600., rest_time, rest_time + 600., rest_time + 1200.],
+        'current': [1., 1., rest_current, -1., -1.],
+        'voltage': [4., 4., 3.8, 3., 3.],
+        'cycle_number': [0] * 5,
+        'state': ['charging', 'charging', 'resting', 'discharging', 'discharging'],
+    })
+
+
+def test_state_of_charge_does_not_integrate_across_rests():
+    """A longer rest must not add a false trapezoid to charge or energy."""
+    short_rest = _data_with_rest(rest_time=4200.)
+    long_rest = _data_with_rest(rest_time=86400.)
+
+    for raw_data in [short_rest, long_rest]:
+        StateOfCharge(coulombic_efficiency=0.9).enhance(raw_data)
+
+    expected_charge = [0., 1 / 6, 1 / 6, 1 / 6, 0.]
+    expected_energy = [0., 2 / 3, 2 / 3, 2 / 3, 1 / 6]
+    expected_ce_charge = [0., 0.15, 0.15, 0.15, -1 / 60]
+
+    for raw_data in [short_rest, long_rest]:
+        assert np.allclose(raw_data['cycled_charge'], expected_charge)
+        assert np.allclose(raw_data['cycled_energy'], expected_energy)
+        assert np.allclose(raw_data['CE_adjusted_charge'], expected_ce_charge)
+
+    assert np.allclose(
+        short_rest[['cycled_charge', 'cycled_energy', 'CE_adjusted_charge']],
+        long_rest[['cycled_charge', 'cycled_energy', 'CE_adjusted_charge']],
+    )
+
+
+def test_state_of_charge_uses_state_label_for_noisy_rests():
+    """A labelled rest remains a no-integration segment despite small leakage current."""
+    raw_data = _data_with_rest(rest_time=4200., rest_current=5.e-5)
+
+    StateOfCharge().enhance(raw_data)
+
+    assert np.isclose(raw_data['cycled_charge'].iloc[2], 1 / 6)
+    assert np.isclose(raw_data['cycled_energy'].iloc[2], 2 / 3)
+    assert np.isclose(raw_data['cycled_charge'].iloc[-1], 0.)
+
+
+def test_state_of_charge_infers_missing_state_without_mutating_data():
+    raw_data = _data_with_rest(rest_time=4200.).drop(columns='state')
+
+    StateOfCharge().enhance(raw_data)
+
+    assert 'state' not in raw_data
+    assert np.allclose(raw_data['cycled_charge'], [0., 1 / 6, 1 / 6, 1 / 6, 0.])


### PR DESCRIPTION
## Problem

`StateOfCharge` integrated across an entire cycle with one trapezoidal
integral. A charge → rest → discharge trace could therefore add artificial
capacity and energy when a sample gap crosses a state boundary.

## Change

- Integrate each contiguous `charging` or `discharging` segment independently.
- Preserve the preceding cumulative value through `resting` and `unknown`
  segments.
- Skip intervals whose endpoint states differ; the exact transition timestamp
  is not present in the input data, so assigning that interval to either state
  would be an undocumented assumption.
- If `state` is absent, infer it locally with the existing `AddState` 0.1 mA
  rest threshold without changing the caller's dataframe.

The same segment handling applies to charge, energy, and CE-adjusted charge.

## Validation

- Added a five-point synthetic charge → rest → discharge regression test.
- Verified that extending only the rest duration does not change calculated
  charge or energy.
- Added labelled noisy-rest and missing-state fallback coverage.
- `pytest tests/postprocess/test_integral.py -q` — 10 passed.
- `flake8 battdat/ tests` and `git diff --check` — passed.

I also ran the complete suite locally. Eight failures are confined to existing
exporter/I/O paths under my Python 3.12 / pandas 3.0 environment (not touched
by this diff); I have not treated them as regressions from this change.

Closes #132
